### PR TITLE
Fixed hint count bug on upgrade island

### DIFF
--- a/Main Project/islandIndex.html
+++ b/Main Project/islandIndex.html
@@ -156,11 +156,19 @@
 
             <div>
                 <h3>Hint Purchase</h3>
-                <p id="hintsLevel">Current Amount of Hints: 0</p>
+                <p id="hintsLevel">Current Amount of Hints: <span id="hintCount">0</span></p>
                 <button onclick="hintsUpgrade.upgrade()">Buy Hint (10 Coins)</button>
             </div>
         </div>
     </div>
+
+    <script>
+        // Retrieve the number of hints from localStorage
+        const hints = parseInt(localStorage.getItem('hints')) || 0;
+  
+        // Update the HTML to show the hints count
+        document.getElementById('hintCount').innerText = `${hints}`;
+    </script>
 
     <div id="pierOverlay" class="overlay">
         <div class="overlay-content">


### PR DESCRIPTION
When you would reload the page on the upgrade island, the hint count in the barracks upgrade menu would show zero until you bought a hint. Now it shows the correct value right away.